### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom/client";
+import ReactDOM from "react-dom";
 import { BrowserRouter as Router } from "react-router-dom";
 import Store from "./redux/Store";
 import { Provider } from "react-redux";


### PR DESCRIPTION
1.Import ReactDOM in the traditional way:

While you've imported ReactDOM from "react-dom/client", it's more common to import it from "react-dom". This ensures consistency with other codebases and makes it clearer that you're using the official ReactDOM package.

2.Import StrictMode directly from React:

You can import StrictMode directly from react without using the React namespace.